### PR TITLE
docs: add link to CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+[pyOpenSci Community Code of Conduct](https://github.com/pyOpenSci/handbook/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Since it took some time for me to get to [pyOpenSci Community Code of Conduct](https://github.com/pyOpenSci/handbook/blob/main/CODE_OF_CONDUCT.md), I suggest creating a `CODE_OF_CONDUCT.md` file and adding a link to it.